### PR TITLE
EASY-1418. URN filled in as DOI.

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.report/EasyDepositReportApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.report/EasyDepositReportApp.scala
@@ -101,7 +101,7 @@ class EasyDepositReportApp(configuration: Configuration) extends DebugEnhancedLo
       id.attribute(XML_NAMESPACE_XSI, "type").exists {
         case Seq(n) =>
           n.text.split(':') match {
-            case Array(pre, _) => id.getNamespace(pre) == XML_NAMESPACE_ID_TYPE
+            case Array(pre, suffix) => id.getNamespace(pre) == XML_NAMESPACE_ID_TYPE && suffix == "DOI"
             case _ => false
           }
       }


### PR DESCRIPTION
Fixes EASY-1418

@DANS-KNAW/easy 

#### When applied it will
* `getDoi`  function only checked the namespace of the xsi:type attribute value, not the suffix 

  