### PR TITLE
EASY-1444 Make DEPOSIT_UPDATE_TIMESTAMP an ISO-date.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,14 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.joda</groupId>
+            <artifactId>joda-convert</artifactId>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/scala/nl.knaw.dans.easy.report/EasyDepositReportApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.report/EasyDepositReportApp.scala
@@ -24,6 +24,7 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.io.FileUtils
+import org.joda.time.{ DateTime, DateTimeZone }
 import resource.managed
 
 import scala.collection.JavaConverters._
@@ -39,7 +40,7 @@ case class Deposit(depositId: DepositId,
                    creationTimestamp: String,
                    numberOfContinuedDeposits: Int,
                    storageSpace: Long,
-                   lastModified: FileTime)
+                   lastModified: String)
 
 class EasyDepositReportApp(configuration: Configuration) extends DebugEnhancedLogging {
   private val KB = 1024L
@@ -63,7 +64,7 @@ class EasyDepositReportApp(configuration: Configuration) extends DebugEnhancedLo
 
         // forall returns true for the empty set, see https://en.wikipedia.org/wiki/Vacuous_truth
         if (filterOnDepositor.forall(depositorId ==)) Some {
-          depositId -> Deposit(
+          Deposit(
             depositId = depositId,
             doi = getDoi(depositProperties, depositDirPath),
             depositorId,
@@ -72,12 +73,11 @@ class EasyDepositReportApp(configuration: Configuration) extends DebugEnhancedLo
             creationTimestamp = depositProperties.getString("creation.timestamp"),
             depositDirPath.list(_.count(_.getFileName.toString.matches("""^.*\.zip\.\d+$"""))),
             storageSpace = FileUtils.sizeOfDirectory(depositDirPath.toFile),
-            lastModified = Files.getLastModifiedTime(depositDirPath)
+            lastModified = new DateTime(Files.getLastModifiedTime(depositDirPath).toInstant.toEpochMilli, DateTimeZone.UTC).toString(dateTimeFormatter)
           )
         }
         else None
       }
-      .toMap
   }
 
   private def getDoi(depositProperties: PropertiesConfiguration, depositDirPath: Path): Option[String] = {
@@ -109,7 +109,7 @@ class EasyDepositReportApp(configuration: Configuration) extends DebugEnhancedLo
   }
 
   private def outputSummary(deposits: Deposits, depositor: Option[DepositorId] = None): Unit = {
-    val selectedDeposits = depositor.map(d => deposits.values.filter(_.depositor == d)).getOrElse(deposits.values)
+    val selectedDeposits = depositor.map(d => deposits.filter(_.depositor == d)).getOrElse(deposits)
     val draft = selectedDeposits.filter(_.state == "DRAFT").toList
     val invalid = selectedDeposits.filter(_.state == "INVALID").toList
     val finalizing = selectedDeposits.filter(_.state == "FINALIZING").toList
@@ -141,21 +141,19 @@ class EasyDepositReportApp(configuration: Configuration) extends DebugEnhancedLo
   }
 
   private def outputFullReport(deposits: Deposits): Unit = {
-    val sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss")
     val csvFormat: CSVFormat = CSVFormat.RFC4180
       .withHeader("DEPOSITOR", "DEPOSIT_ID", "DEPOSIT_STATE", "DOI", "DEPOSIT_CREATION_TIMESTAMP",
         "DEPOSIT_UPDATE_TIMESTAMP", "DESCRIPTION", "NBR_OF_CONTINUED_DEPOSITS", "STORAGE_IN_BYTES")
       .withDelimiter(',')
     val printer = csvFormat.print(Console.out)
-    deposits.keys.foreach { depositId =>
-      val deposit = deposits(depositId)
+    deposits.sortBy(_.creationTimestamp)foreach { deposit =>
       printer.printRecord(
         deposit.depositor,
-        depositId,
+        deposit.depositId,
         deposit.state,
         deposit.doi.getOrElse("n/a"),
         deposit.creationTimestamp,
-        sdf.format(deposit.lastModified.toMillis),
+        deposit.lastModified,
         deposit.description,
         deposit.numberOfContinuedDeposits.toString,
         deposit.storageSpace.toString)

--- a/src/main/scala/nl.knaw.dans.easy.report/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.report/package.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy
 
 import java.nio.file.{ Files, Path }
 
+import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
 import resource._
 
 import scala.collection.JavaConverters._
@@ -24,11 +25,13 @@ import scala.collection.JavaConverters._
 package object report {
 
   type DepositId = String
-  type Deposits = Map[DepositId, Deposit]
+  type Deposits = Seq[Deposit]
   type DepositorId = String
 
   val XML_NAMESPACE_XSI = "http://www.w3.org/2001/XMLSchema-instance"
   val XML_NAMESPACE_ID_TYPE = "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
+
+  val dateTimeFormatter: DateTimeFormatter = ISODateTimeFormat.dateTime()
 
   implicit class PathExtensions(val path: Path) extends AnyVal {
     def list[T](f: Stream[Path] => T): T = {


### PR DESCRIPTION
Fixes EASY-1444

#### When applied it will
* Make the DEPOSIT_UPDATE_TIMESTAMP an ISO date
* Sort the output of the full report on DEPOSIT_UPDATE_TIMESTAMP (extra)
* Refactored away the unnecessary Map, and replaced it with a Seq.

@DANS-KNAW/easy 