### PR TITLE
using Java's Stream API, now we have Scala_2.12

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.report/EasyDepositReportApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.report/EasyDepositReportApp.scala
@@ -28,6 +28,7 @@ import resource.managed
 
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
+import scala.math.Ordering.{ Long => LongComparator }
 import scala.util.Try
 import scala.xml.{ NodeSeq, XML }
 
@@ -81,9 +82,10 @@ class EasyDepositReportApp(configuration: Configuration) extends DebugEnhancedLo
 
   private def getLastModifiedTimestamp(depositDirPath: Path): String = {
     managed(Files.list(depositDirPath)).acquireAndGet { files =>
-      val modifiedMillisForFilesInDepositDir = files.iterator().asScala.toList.map(Files.getLastModifiedTime(_).toInstant.toEpochMilli)
-      if (modifiedMillisForFilesInDepositDir.isEmpty) "n/a"
-      else new DateTime(modifiedMillisForFilesInDepositDir.max, DateTimeZone.UTC).toString(dateTimeFormatter)
+      files.map(Files.getLastModifiedTime(_).toInstant.toEpochMilli)
+        .max(LongComparator)
+        .map(millis => new DateTime(millis, DateTimeZone.UTC).toString(dateTimeFormatter))
+        .orElse("n/a")
     }
   }
 


### PR DESCRIPTION
Following my [comment](https://github.com/DANS-KNAW/easy-deposit-report/pull/10#pullrequestreview-89939147) on #10, I thought I might as well commit it as well.

@DANS-KNAW/easy for review

_(**Please note:** I'm not calling for going through all our code at once and remove all the `jStream.iterator.asScala.toList` constructs, but we need to get in the habit of using the API's we have to our disposal, rather than using these workarounds!)_