### PR TITLE
NO JIRA. Replaced record separator for csv.

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.report/EasyDepositReportApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.report/EasyDepositReportApp.scala
@@ -154,6 +154,7 @@ class EasyDepositReportApp(configuration: Configuration) extends DebugEnhancedLo
       .withHeader("DEPOSITOR", "DEPOSIT_ID", "DEPOSIT_STATE", "DOI", "DEPOSIT_CREATION_TIMESTAMP",
         "DEPOSIT_UPDATE_TIMESTAMP", "DESCRIPTION", "NBR_OF_CONTINUED_DEPOSITS", "STORAGE_IN_BYTES")
       .withDelimiter(',')
+      .withRecordSeparator('\n')
     val printer = csvFormat.print(Console.out)
     deposits.sortBy(_.creationTimestamp) foreach { deposit =>
       printer.printRecord(


### PR DESCRIPTION
Replace the default x0d x0a record separator with just x0a, the Linux standard.
The mail program seems to replace x0a with x0d x0a, as this is the standard in
web protocols. This left us with an extra newline in the CSV output and therefore
with blank rows.